### PR TITLE
jfilter modified

### DIFF
--- a/doc/specification.org
+++ b/doc/specification.org
@@ -214,6 +214,40 @@ events and their times will be logged. The client may accept input during
 operation to adjust these parameters, and it may provide information on the
 terminal as to the current state of the detector.
 
+** jfilter
+
+The function of *jfilter* is to filter the input data according to cutoff frequency 
+threshold. Filter types (high-pass, low-pass, band-pass, band-stop), cutoff 
+frequencies, orders (number of poles), or custom numerator and demoninator coefficients
+need to be specified.
+
+So far, jfilter only support Butterworth filter method. When using a big number(>=10) 
+for order and small cutoff frequency (order >= 10 for freq <= 300, and order >= 15 for
+freq <= 500), jfilter doesn't work as it supposed to be.
+
+*** JACK Ports                                                       :rel2_0:
+
++ in_NNN :: input. NNN is a numerical index. The number of ports and their type
+            is determined at startup by specifying a list of ports to connect to
+            the client.  The client may also create custom-named ported as
+            specified by the user.
++ out_NNN :: correspondent processed data, output. 
+
+The client will not make any changes to its port configuration during operation.
+
+*** JACK Events                                                      :rel2_0:
+
+1. When xrun happens, pads_reset is called to reset infinite impulse response.
+
+*** Options and behavior
+
+**** commandline options                                             :rel2_0:
+
+1. Filter type. Choose from high-pass, low-pass, band-pass, and band-stop.
+2. Cutoff frequency. 
+3. Order. Number of poles.
+4. Numerator and denominator. Parameters used for custom filter design.
+
 ** jflip
 
 The function of *jflip* is to whiten the input data by randomly inverting it around

--- a/doc/specification.org
+++ b/doc/specification.org
@@ -221,15 +221,16 @@ threshold. Filter types (high-pass, low-pass, band-pass, band-stop), cutoff
 frequencies, orders (number of poles), or custom numerator and demoninator coefficients
 need to be specified.
 
-So far, jfilter only support Butterworth filter method. When using a big number(>=10) 
-for order and small cutoff frequency (order >= 10 for freq <= 300, and order >= 15 for
-freq <= 500), jfilter doesn't work as it supposed to be.
+So far, jfilter only implements Butterworth filters. Because the digital implementation
+is an IIR design, high-order (greater than about 8) filters may become unstable and
+generate undefined outputs. This behavior is more likely to occur when the cutoff
+frequencies are near either zero or the Nyquist frequency.
 
 *** JACK Ports                                                       :rel2_0:
 
 + in_NNN :: input. NNN is a numerical index. The number of ports and their type
             is determined at startup by specifying a list of ports to connect to
-            the client.  The client may also create custom-named ported as
+            the client.  The client may also create custom-named ports, as
             specified by the user.
 + out_NNN :: correspondent processed data, output. 
 
@@ -237,7 +238,7 @@ The client will not make any changes to its port configuration during operation.
 
 *** JACK Events                                                      :rel2_0:
 
-1. When xrun happens, pads_reset is called to reset infinite impulse response.
+1. When an xrun occurs, pads_reset is called to reset infinite impulse response.
 
 *** Options and behavior
 
@@ -246,7 +247,8 @@ The client will not make any changes to its port configuration during operation.
 1. Filter type. Choose from high-pass, low-pass, band-pass, and band-stop.
 2. Cutoff frequency. 
 3. Order. Number of poles.
-4. Numerator and denominator. Parameters used for custom filter design.
+4. Numerator and denominator. Pre-calculated parameters used for custom filter
+   design. These would be used in place of type, cutoff frequency, and order.
 
 ** jflip
 

--- a/jill/digital_filter.cc
+++ b/jill/digital_filter.cc
@@ -108,11 +108,14 @@ digital_filter::custom_coef(std::vector<COEF_t> b,
 
 void 
 digital_filter::reset_pads() {
+        
         std::map<std::string, std::vector<COEF_t> >::iterator it_in, it_out;
         if (is_iir()) {
                 it_out = _pads_out.begin();
         }
-        for (it_in = _pads_in.begin(); it_in != _pads_out.end(); it_in++) {
+        
+        // fix the bug in the for loop
+        for (it_in = _pads_in.begin(); it_in != _pads_in.end(); it_in++) {
                 it_in->second.assign(it_in->second.size(), 0);
                 if (is_iir()) {
                         it_out->second.assign(it_out->second.size(), 0);

--- a/jill/transfer_function.cc
+++ b/jill/transfer_function.cc
@@ -7,6 +7,7 @@ using namespace jill;
 
 
 transfer_function::transfer_function(poly b, poly a) {
+        LOG << "transfer_function(b,a)";
         _numerator=b;
         _denominator=a;
         _is_analog_bool=true;
@@ -15,6 +16,7 @@ transfer_function::transfer_function(poly b, poly a) {
 transfer_function::transfer_function(std::vector<complex_t> z, 
                                      std::vector<complex_t> p,
                                      COEF_t k) {
+        LOG << "transfer_function(z,p,k)"; // LOG added to fix stack smashing error
         complex_t identity[0];
         identity[0] = complex_t(1,0);
         complex_poly num(identity, 0);
@@ -73,7 +75,7 @@ transfer_function::transform(poly transform_num, poly transform_denom){
        // with the numerator and denominator of the transfer function in
        // order to put the transfer function back into rational form
        int n = std::max(_numerator.degree(), _denominator.degree());
-       
+       LOG << "transform";
        poly new_num(0);
        poly new_denom(0);
        for (int k = 0; k < std::max(_numerator.size(), 


### PR DESCRIPTION
1. Fixed the problem of jfilter turning into zombified process when xrun happens. "jfilter" can be terminated properly.
2. Fix the bug in reset_pads in jfilter handling xruns.
3. Fix the problem of stack smashing.
4. Added jfilter module description.